### PR TITLE
Make sure to leave squad channel before join

### DIFF
--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -149,6 +149,9 @@ var squadScoreField = $('.squad-score')
 
 let join = $(".join", squadForm)
 let joining = () => {
+  if (squadChannel) {
+    squadChannel.leave()
+  }
   squadChannel = socket.channel("arenas:squads:" + squadName.val())
 
   squadChannel.join().receive("ok", resp => {


### PR DESCRIPTION
Fixes #2 
If we already joined a sqaud channel, we should leave before joining
another.
Eventually, we should make the server-side check for this as well.
However, it's fairly non-trivial to implement. Seems like there is
already support for this in the current master branch of Phoenix so we
will just wait for that.
