### PR TITLE
Roster

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -5,7 +5,7 @@ defmodule Gyro.Arena do
   alias Gyro.Spinner
   alias Gyro.Squad
 
-  defstruct spinner_roster: %{}, squad_roster: %{},
+  defstruct spinner_roster: nil, squad_roster: nil,
     legendary_spinners: [], legendary_squads: [],
     heroic_spinners: [], heroic_squads: [],
     loudest_squads: []
@@ -14,12 +14,19 @@ defmodule Gyro.Arena do
   @timer 1000
 
   @doc """
-  Start a GenServer. A permutation without param input is needed for the
-  Application Supervisor children.
+  Start the arena GenServer by first starts 2 Agents: one for tracking active
+  spinners, and another for tracking active squads in the system. One both
+  Agents are started successfully, we then start the Arena GenServer.
+  If either of the Agents fails to start, it returns the error from that
+  Agent and not starts the arena GenServer.
   """
-  def start_link, do: start_link(%Arena{})
-  def start_link(state) do
-    GenServer.start_link(__MODULE__, state, name: {:global, @name})
+  def start_link(state \\ %Arena{}) do
+    with {:ok, spinner_roster} <- Agent.start_link((fn() -> [] end)),
+    {:ok, squad_roster} <- Agent.start_link((fn() -> [] end))
+    do
+      state = %{state | spinner_roster: spinner_roster, squad_roster: squad_roster}
+      GenServer.start_link(__MODULE__, state, name: {:global, @name})
+    end
   end
 
 end

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -11,7 +11,15 @@ defmodule Gyro.Arena do
     loudest_squads: []
 
   @name :arena
+  @pid {:global, @name}
   @timer 1000
+
+  @doc """
+  Add a new spinner to the spinner roster
+  """
+  def enlist(spinner_pid) do
+    GenServer.call(@pid, {:enlist, spinner_pid})
+  end
 
   @doc """
   Start the arena GenServer by first starts 2 Agents: one for tracking active
@@ -27,6 +35,16 @@ defmodule Gyro.Arena do
       state = %{state | spinner_roster: spinner_roster, squad_roster: squad_roster}
       GenServer.start_link(__MODULE__, state, name: {:global, @name})
     end
+  end
+
+  @doc """
+  Add the given spinner id to the spinner roster Agent.
+  """
+  def handle_call({:enlist, spinner_pid}, _from, state) do
+    state.spinner_roster
+    |> Agent.update(fn(state) -> [spinner_pid | state] end)
+
+    {:reply, state, state}
   end
 
 end

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -5,24 +5,13 @@ defmodule Gyro.Arena do
   alias Gyro.Spinner
   alias Gyro.Squad
 
-  defstruct legendary_spinners: [], legendary_squads: [],
+  defstruct spinner_roster: %{}, squad_roster: %{},
+    legendary_spinners: [], legendary_squads: [],
     heroic_spinners: [], heroic_squads: [],
     loudest_squads: []
 
   @name :arena
   @timer 1000
-
-  @doc """
-  Shortcut method for starting
-  """
-  def start do
-    case start_link(%Arena{}) do
-      {:ok, pid} ->
-        # :timer.send_interval(@timer, pid, :spin)
-        {:ok, pid}
-      {:error, reason} -> {:error, reason}
-    end
-  end
 
   @doc """
   Start a GenServer. A permutation without param input is needed for the

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -29,8 +29,8 @@ defmodule Gyro.Arena do
   Agent and not starts the arena GenServer.
   """
   def start_link(state \\ %Arena{}) do
-    with {:ok, spinner_roster} <- Agent.start_link((fn() -> [] end)),
-    {:ok, squad_roster} <- Agent.start_link((fn() -> [] end))
+    with {:ok, spinner_roster} <- Agent.start_link((fn() -> %{} end)),
+    {:ok, squad_roster} <- Agent.start_link((fn() -> %{} end))
     do
       state = %{state | spinner_roster: spinner_roster, squad_roster: squad_roster}
       GenServer.start_link(__MODULE__, state, name: {:global, @name})
@@ -40,9 +40,11 @@ defmodule Gyro.Arena do
   @doc """
   Add the given spinner id to the spinner roster Agent.
   """
-  def handle_call({:enlist, spinner_pid}, _from, state) do
-    state.spinner_roster
-    |> Agent.update(fn(state) -> [spinner_pid | state] end)
+  def handle_call({:enlist, spinner_pid}, _from, state = %{spinner_roster: spinner_roster}) do
+    spinner_roster
+    |> Agent.update(fn(state) ->
+      Map.put(state, :erlang.pid_to_list(spinner_pid), spinner_pid)
+    end)
 
     {:reply, state, state}
   end

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -22,6 +22,13 @@ defmodule Gyro.Arena do
   end
 
   @doc """
+  Remove a spinner from the spinner roster
+  """
+  def delist(spinner_pid) do
+    GenServer.call(@pid, {:delist, spinner_pid})
+  end
+
+  @doc """
   Start the arena GenServer by first starts 2 Agents: one for tracking active
   spinners, and another for tracking active squads in the system. One both
   Agents are started successfully, we then start the Arena GenServer.
@@ -44,6 +51,18 @@ defmodule Gyro.Arena do
     spinner_roster
     |> Agent.update(fn(state) ->
       Map.put(state, :erlang.pid_to_list(spinner_pid), spinner_pid)
+    end)
+
+    {:reply, state, state}
+  end
+
+  @doc """
+  Remove the given spinner id from the spinner roster Agent.
+  """
+  def handle_call({:delist, spinner_pid}, _from, state = %{spinner_roster: spinner_roster}) do
+    spinner_roster
+    |> Agent.update(fn(state) ->
+      Map.delete(state, :erlang.pid_to_list(spinner_pid))
     end)
 
     {:reply, state, state}

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -12,7 +12,7 @@ defmodule Gyro.Spinner do
   @doc """
   The main method for starting a new spinner GenServer for a given socket.
   """
-  def start(socket = %Socket{}) do
+  def enlist(socket = %Socket{}) do
     case start_link(%Spinner{}) do
       {:ok, spinner_pid} ->
         socket = Socket.assign(socket, :spinner_pid, spinner_pid)
@@ -41,7 +41,7 @@ defmodule Gyro.Spinner do
   @doc """
   Stop the squad GenServer assigned to the given socket with a given reason
   """
-  def stop(socket = %Socket{assigns: %{spinner_pid: spinner_pid}}, reason \\ :normal) do
+  def delist(socket = %Socket{assigns: %{spinner_pid: spinner_pid}}, reason \\ :normal) do
     GenServer.stop(spinner_pid, reason)
 
     socket

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -1,6 +1,7 @@
 defmodule Gyro.Spinner do
   use GenServer
 
+  alias Gyro.Arena
   alias Gyro.Spinner
   alias Phoenix.Socket
 
@@ -15,6 +16,7 @@ defmodule Gyro.Spinner do
   def enlist(socket = %Socket{}) do
     case start_link(%Spinner{}) do
       {:ok, spinner_pid} ->
+        Arena.enlist(spinner_pid)
         socket = Socket.assign(socket, :spinner_pid, spinner_pid)
         {:ok, socket}
       {:error, _} ->
@@ -42,6 +44,7 @@ defmodule Gyro.Spinner do
   Stop the squad GenServer assigned to the given socket with a given reason
   """
   def delist(socket = %Socket{assigns: %{spinner_pid: spinner_pid}}, reason \\ :normal) do
+    Arena.delist(spinner_pid)
     GenServer.stop(spinner_pid, reason)
 
     socket

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -18,7 +18,7 @@ defmodule Gyro.Squad do
   back as if we successfully started the squad. Otherwise, pass the `:error`
   status and reason back.
   """
-  def start(name) do
+  def form(name) do
     case start_link(%Squad{name: name}, name) do
       {:ok, squad_pid} ->
         {:ok, squad_pid}
@@ -36,7 +36,7 @@ defmodule Gyro.Squad do
     socket |> delist |> enlist(name)
   end
   def enlist(socket = %Socket{assigns: %{spinner_pid: spinner_pid}}, name) do
-    case start(name) do
+    case form(name) do
       {:ok, squad_pid} ->
         GenServer.call(squad_pid, {:enlist, spinner_pid})
         {:ok, Socket.assign(socket, :squad_pid, squad_pid)}
@@ -67,7 +67,7 @@ defmodule Gyro.Squad do
   @doc """
   Stop the squad GenServer assigned to the given socket with a given reason
   """
-  def stop(socket = %Socket{assigns: %{squad_pid: squad_pid}}, reason \\ :normal) do
+  def disband(socket = %Socket{assigns: %{squad_pid: squad_pid}}, reason \\ :normal) do
     GenServer.stop(squad_pid, reason)
 
     socket

--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -22,4 +22,15 @@ defmodule Gyro.ArenaTest do
     assert spinner_pid == listed_pid
   end
 
+  test "removing a spinner", %{socket: %{assigns: %{spinner_pid: spinner_pid}}} do
+    Arena.enlist(spinner_pid)
+    %{spinner_roster: spinner_roster} = Arena.delist(spinner_pid)
+    listed_pid = Agent.get(spinner_roster, fn(state) ->
+      state
+      |> Map.get(:erlang.pid_to_list(spinner_pid))
+    end)
+
+    assert listed_pid == nil
+  end
+
 end

--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -13,8 +13,11 @@ defmodule Gyro.ArenaTest do
   end
 
   test "adding a new spinner", %{socket: %{assigns: %{spinner_pid: spinner_pid}}} do
-     %{spinner_roster: spinner_roster} = Arena.enlist(spinner_pid)
-    [listed_pid] = Agent.get(spinner_roster, fn(state) -> state end)
+    %{spinner_roster: spinner_roster} = Arena.enlist(spinner_pid)
+    listed_pid = Agent.get(spinner_roster, fn(state) ->
+      state
+      |> Map.get(:erlang.pid_to_list(spinner_pid))
+    end)
 
     assert spinner_pid == listed_pid
   end

--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -1,8 +1,22 @@
 defmodule Gyro.ArenaTest do
   use ExUnit.Case, async: true
+  use Gyro.ChannelCase
 
-  test "start arena correctly" do
-    assert true
+  alias Gyro.UserSocket
+  alias Gyro.Arena
+
+  setup do
+    socket = socket("user_id", %{})
+    {:ok, socket} = UserSocket.connect(nil, socket)
+
+    {:ok, socket: socket}
+  end
+
+  test "adding a new spinner", %{socket: %{assigns: %{spinner_pid: spinner_pid}}} do
+     %{spinner_roster: spinner_roster} = Arena.enlist(spinner_pid)
+    [listed_pid] = Agent.get(spinner_roster, fn(state) -> state end)
+
+    assert spinner_pid == listed_pid
   end
 
 end

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -52,8 +52,8 @@ defmodule Gyro.SquadTest do
     refute is_member?(spinner_pid, squad_pid)
   end
 
-  test "start a squad" do
-    {status, _} = Squad.start("TIM")
+  test "form a squad" do
+    {status, _} = Squad.form("TIM")
     assert :ok == status
   end
 

--- a/web/channels/arena_channel.ex
+++ b/web/channels/arena_channel.ex
@@ -22,7 +22,7 @@ defmodule Gyro.ArenaChannel do
   we would want stop the GenServer when the user leave `arena` channel.
   """
   def terminate(_, socket) do
-    Spinner.stop(socket)
+    Spinner.delist(socket)
   end
 
   @doc """

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -33,7 +33,7 @@ defmodule Gyro.UserSocket do
     # socket at this level will be available to every channels.
     # TODO: switch to using some other user id method.
     #{:ok, socket}
-    Spinner.start(socket)
+    Spinner.enlist(socket)
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:


### PR DESCRIPTION
Started on the another GenServer process for managing lists of spinners and squads in the system. It works by starting 2 Agents, one for spinners and one for squads. The Agents hold a map as its state for quickly look up of spinner or squad but still be able to iterate through.

For now, it's not doing anything beside registering the pids into the spinner Agent yet.
