### PR TITLE
Socket dependency

### DIFF
--- a/web/channels/squad_channel.ex
+++ b/web/channels/squad_channel.ex
@@ -1,5 +1,6 @@
 defmodule Gyro.SquadChannel do
   use Gyro.Web, :channel
+  alias Phoenix.Socket
   alias Gyro.Squad
 
   @timer 5000
@@ -10,11 +11,11 @@ defmodule Gyro.SquadChannel do
   The name of the squad is defined by the user which is then by Squad GenServer
   to look up with.
   """
-  def join("arenas:squads:" <> name, payload, socket) do
+  def join("arenas:squads:" <> name, payload, socket = %Socket{assigns: %{spinner_pid: spinner_pid}}) do
     if authorized?(payload) do
-      resp = Squad.enlist(socket, name)
+      {:ok, squad_pid} = Squad.enlist(name, spinner_pid)
       send(self, :init)
-      resp
+      {:ok, assign(socket, :squad_pid, squad_pid)}
     else
       {:error, %{reason: "unauthorized"}}
     end
@@ -25,8 +26,8 @@ defmodule Gyro.SquadChannel do
   we want to remove the user from the squad they belong to as stored in the
   socket's `assigns` key.
   """
-  def terminate(_, socket) do
-    Squad.delist(socket)
+  def terminate(_, %Socket{assigns: %{squad_pid: squad_pid, spinner_pid: spinner_pid}}) do
+    Squad.delist(squad_pid, spinner_pid)
   end
 
   def handle_info(:init, socket) do
@@ -39,13 +40,14 @@ defmodule Gyro.SquadChannel do
   Event handler for the infinite spinning loop. Currently it calls Squad
   GenServer to get the state of the squad to report back to client
   """
-  def handle_info(:spin, socket) do
-    socket = Squad.introspect(socket)
-    payload = socket.assigns[:squad]
+  def handle_info(:spin, socket = %Socket{assigns: %{squad_pid: squad_pid}}) do
+    squad = Squad.introspect(squad_pid)
     |> Map.delete(:formed_at)
     |> Map.delete(:members)
 
-    push socket, "introspect", payload
+    socket = assign(socket, :squad, squad)
+
+    push socket, "introspect", squad
     {:noreply, socket}
   end
 

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -33,7 +33,8 @@ defmodule Gyro.UserSocket do
     # socket at this level will be available to every channels.
     # TODO: switch to using some other user id method.
     #{:ok, socket}
-    Spinner.enlist(socket)
+    {:ok, spinner_pid} = Spinner.enlist()
+    {:ok, assign(socket, :spinner_pid, spinner_pid)}
   end
 
   # Socket id's are topics that allow you to identify all sockets for a given user:


### PR DESCRIPTION
Remove Socket dependency from both the Squad and Spinner GenServer. This should make the client API of the GenServer reusable outside of the channel context.
