### PR TITLE
Start a new Squad under the Application Supervisor

### DIFF
--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -41,9 +41,17 @@ defmodule Gyro.SquadTest do
     refute is_member?(spinner_pid, squad_pid)
   end
 
-  test "form a squad" do
+  test "form a squad spawn process links to application supervisor" do
     {status, _} = Squad.form("TIM")
+
     assert :ok == status
+
+    #squad_pid = GenServer.whereis(squad_pid)
+    #has_squad = Supervisor.which_children(Gyro.Supervisor)
+    #  |> Enum.any?(fn({_, child_pid, _, _}) ->
+    #    child_pid == squad_pid
+    #  end)
+    #assert has_squad
   end
 
   test "enlist a member", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do


### PR DESCRIPTION
Fixes #8 

Instead of starting a Squad, linked to the spinner process that
requested it, we should be linking it to a different Supervisor. Linking
the Squad to a spinner process will cause it to terminate when that
spinner leaves.
However, creating an entirely new Supervisor just for the Squads seems a
little overkill. For now, we're just asking the Application
`Gyro.Supervisor` to supervise the squads for us.
