### PR TITLE
Fix pattern matching for Spinner `exists/1`

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -107,8 +107,8 @@ defmodule Gyro.Arena do
     spinners
     |> Enum.map(fn({_, spinner_pid}) ->
       case Spinner.exists?(spinner_pid) do
-        nil -> %{score: 0, spm: 0}
-        _ -> Spinner.introspect(spinner_pid) |> Map.delete(:connected_at)
+        false -> %{score: 0, spm: 0}
+        true -> Spinner.introspect(spinner_pid) |> Map.delete(:connected_at)
       end
     end)
   end

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -162,8 +162,8 @@ defmodule Gyro.Squad do
   # spinner pid.
   defp inspect_spinner(spinner_pid) do
     case Spinner.exists?(spinner_pid) do
-      nil -> %{score: 0, spm: 0}
-      _ -> Spinner.introspect(spinner_pid)
+      false -> %{score: 0, spm: 0}
+      true -> Spinner.introspect(spinner_pid)
     end
   end
 


### PR DESCRIPTION
Fix #11 

In Squad and Arena where we're updating spinners, we check whether the
spinner still exists or not. However, the pattern matching for the
conditions were incorrect. We should be watching for boolean instead of
nil or has value.
