### PR TITLE
Pattern matching on no process error

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -106,9 +106,9 @@ defmodule Gyro.Arena do
   defp update_spinners(spinners) do
     spinners
     |> Enum.map(fn({_, spinner_pid}) ->
-      case Spinner.exists?(spinner_pid) do
-        false -> %{score: 0, spm: 0}
-        true -> Spinner.introspect(spinner_pid) |> Map.delete(:connected_at)
+      case Spinner.introspect(spinner_pid) do
+        nil -> %Spinner{score: 0, spm: 0}
+        state -> state |> Map.delete(:connected_at)
       end
     end)
   end

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -30,9 +30,23 @@ defmodule Gyro.Spinner do
   end
 
   @doc """
-  Inspect the current state of the specified spinner.
+  Inspect the current state of the specified spinner. If the spinner is not
+  found, the function will catch the error message thrown by GenServer and
+  return `nil` value as a result instead.
   """
   def introspect(spinner_pid) do
+    try do
+      introspect!(spinner_pid)
+    catch
+      :exit, {:noproc, _} -> nil
+    end
+  end
+
+  @doc """
+  Inspect the current state of the specified spinner. If the spinner is not
+  found, GenServer will, by default, throw a message.
+  """
+  def introspect!(spinner_pid) do
     GenServer.call(spinner_pid, :introspect)
   end
 

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -108,7 +108,7 @@ defmodule Gyro.Squad do
   of the spinner.
   """
   def handle_call({:enlist, spinner_pid}, _from, state) do
-    member = {spinner_pid, inspect_spinner(spinner_pid)}
+    member = {spinner_pid, %{}}
     state = Map.put(state, :members, [member | state.members])
     {:reply, state, state}
   end
@@ -158,21 +158,15 @@ defmodule Gyro.Squad do
     {:noreply, state}
   end
 
-  # Private method for getting the current state of a spinner for a given
-  # spinner pid.
-  defp inspect_spinner(spinner_pid) do
-    case Spinner.exists?(spinner_pid) do
-      false -> %{score: 0, spm: 0}
-      true -> Spinner.introspect(spinner_pid)
-    end
-  end
-
   # Private method for iterating through members in the squad state and
   # update each member current state.
-  # TODO: check if member exists first too
   defp update_members(state) do
     members = Enum.map(state.members, fn({spinner_pid, _}) ->
-      {spinner_pid, inspect_spinner(spinner_pid)}
+      spinner = case Spinner.introspect(spinner_pid) do
+          nil -> %Spinner{score: 0, spm: 0}
+          state -> state
+        end
+      {spinner_pid, spinner}
     end)
     Map.put(state, :members, members)
   end

--- a/test/gyro/spinner_test.exs
+++ b/test/gyro/spinner_test.exs
@@ -32,11 +32,24 @@ defmodule Gyro.SpinnerTest do
     assert Spinner.exists?(spinner_pid)
   end
 
+  @tag :skip
+  test "delist a spinner", %{spinner_pid: spinner_pid} do
+    Spinner.delist(spinner_pid)
+    refute Spinner.exists?(spinner_pid)
+  end
+
   test "introspecting a spinner", %{spinner_pid: spinner_pid} do
     state = Spinner.introspect(spinner_pid)
 
     refute is_nil(state.score)
     assert state.spm == 1
+  end
+
+  test "introspecting a dead spinner", %{spinner_pid: spinner_pid} do
+    Spinner.delist(spinner_pid)
+    state = Spinner.introspect(spinner_pid)
+
+    assert nil == state
   end
 
   test "update spinner state", %{spinner_pid: spinner_pid} do


### PR DESCRIPTION
Better fix for #11 
Apparently the GenServer could exit between checking if it exists and
calling for `introspect`. The better way to handle this is to actually
catch for response from `introspect`. If it comes back with `{:noproc,_}`
message then we can handle that the spinner isn't there any more.
This is probably more solid way to approach this.
