### PR TITLE
Squad members

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -66,7 +66,7 @@ defmodule Gyro.Arena do
   def handle_call({:enlist, spinner_pid}, _from, state = %{spinner_roster: spinner_roster}) do
     spinner_roster
     |> Agent.update(fn(spinners) ->
-      Map.put(spinners, :erlang.pid_to_list(spinner_pid), spinner_pid)
+      Map.put(spinners, spinner_pid, spinner_pid)
     end)
 
     {:reply, state, state}
@@ -78,7 +78,7 @@ defmodule Gyro.Arena do
   def handle_call({:delist, spinner_pid}, _from, state = %{spinner_roster: spinner_roster}) do
     spinner_roster
     |> Agent.update(fn(spinners) ->
-      Map.delete(spinners, :erlang.pid_to_list(spinner_pid))
+      Map.delete(spinners, spinner_pid)
     end)
 
     {:reply, state, state}

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -107,7 +107,7 @@ defmodule Gyro.Arena do
     spinners
     |> Enum.map(fn({_, spinner_pid}) ->
       case Spinner.introspect(spinner_pid) do
-        nil -> %Spinner{score: 0, spm: 0}
+        nil -> %Spinner{score: 0, spm: 0} |> Map.delete(:connected_at)
         state -> state |> Map.delete(:connected_at)
       end
     end)

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -108,7 +108,7 @@ defmodule Gyro.Squad do
   of the spinner.
   """
   def handle_call({:enlist, spinner_pid}, _from, state = %{members: members}) do
-    members = Map.put(members, :erlang.pid_to_list(spinner_pid), spinner_pid)
+    members = Map.put(members, spinner_pid, spinner_pid)
     state = Map.put(state, :members, members)
     {:reply, state, state}
   end
@@ -121,7 +121,7 @@ defmodule Gyro.Squad do
   listing map by key right now.
   """
   def handle_call({:delist, quitter_pid}, _from, state = %{members: members}) do
-    members = Map.delete(members, :erlang.pid_to_list(quitter_pid))
+    members = Map.delete(members, quitter_pid)
     state = Map.put(state, :members, members)
     {:reply, state, state}
   end

--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -16,7 +16,7 @@ defmodule Gyro.ArenaTest do
     %{spinner_roster: spinner_roster} = Arena.enlist(spinner_pid)
     listed_pid = Agent.get(spinner_roster, fn(state) ->
       state
-      |> Map.get(:erlang.pid_to_list(spinner_pid))
+      |> Map.get(spinner_pid)
     end)
 
     assert spinner_pid == listed_pid
@@ -27,7 +27,7 @@ defmodule Gyro.ArenaTest do
     %{spinner_roster: spinner_roster} = Arena.delist(spinner_pid)
     listed_pid = Agent.get(spinner_roster, fn(state) ->
       state
-      |> Map.get(:erlang.pid_to_list(spinner_pid))
+      |> Map.get(spinner_pid)
     end)
 
     assert listed_pid == nil

--- a/test/gyro/spinner_test.exs
+++ b/test/gyro/spinner_test.exs
@@ -22,7 +22,7 @@ defmodule Gyro.SpinnerTest do
     {:ok, spinner_pid} = Spinner.enlist()
     %{spinner_roster: spinner_roster} = Arena.introspect()
     found_pid = Agent.get(spinner_roster, fn(state) ->
-      Map.get(state, :erlang.pid_to_list(spinner_pid))
+      Map.get(state, spinner_pid)
     end)
 
     assert spinner_pid == found_pid

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -29,7 +29,7 @@ defmodule Gyro.SquadTest do
   test "enlist a spinner to a squad", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
     %{members: members} = GenServer.call(squad_pid, {:enlist, spinner_pid})
 
-    assert Map.has_key?(members, :erlang.pid_to_list(spinner_pid))
+    assert Map.has_key?(members, spinner_pid)
     assert is_member?(spinner_pid, squad_pid)
   end
 
@@ -84,6 +84,6 @@ defmodule Gyro.SquadTest do
   defp is_member?(spinner_pid, squad_id) when is_pid(spinner_pid) do
     %{members: members} = GenServer.call(squad_id, :introspect)
 
-    Map.has_key?(members, :erlang.pid_to_list(spinner_pid))
+    Map.has_key?(members, spinner_pid)
   end
 end

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -27,9 +27,9 @@ defmodule Gyro.SquadTest do
   end
 
   test "enlist a spinner to a squad", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
-    %{members: [{member_pid, _} | _]} = GenServer.call(squad_pid, {:enlist, spinner_pid})
+    %{members: members} = GenServer.call(squad_pid, {:enlist, spinner_pid})
 
-    assert spinner_pid == member_pid
+    assert Map.has_key?(members, :erlang.pid_to_list(spinner_pid))
     assert is_member?(spinner_pid, squad_pid)
   end
 
@@ -37,7 +37,7 @@ defmodule Gyro.SquadTest do
     GenServer.call(squad_pid, {:enlist, spinner_pid})
 
     %{members: members} = GenServer.call(squad_pid, {:delist, spinner_pid})
-    assert [] == members
+    assert %{} == members
     refute is_member?(spinner_pid, squad_pid)
   end
 
@@ -84,9 +84,6 @@ defmodule Gyro.SquadTest do
   defp is_member?(spinner_pid, squad_id) when is_pid(spinner_pid) do
     %{members: members} = GenServer.call(squad_id, :introspect)
 
-    nil != members
-      |> Enum.find(fn({member_pid, _}) ->
-        member_pid == spinner_pid
-      end)
+    Map.has_key?(members, :erlang.pid_to_list(spinner_pid))
   end
 end


### PR DESCRIPTION
Fixes #16

Squads now store members as Map for faster lookup, but the same ability to iterate through the list. We also no longer store the Spinner state in the Squad's member list anymore. This should make the Squad state much leaner and cleaner. And hopefully some how improve memory foot print a little.
