### PR TITLE
Add processing monitoring Squad enlisting

### DIFF
--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -34,7 +34,7 @@ defmodule Gyro.ArenaTest do
     assert listed_pid == nil
   end
 
-  test "inspecting the arena", %{spinner_pid: spinner_pid} do
+  test "inspecting the arena" do
     state = Arena.introspect()
 
     assert is_pid(state.spinner_roster)


### PR DESCRIPTION
First step toward #15.

When enlist a new Spinner to a Squad, we now monitor the Spinner's
process and handle the down message in the case that the Spinner process
is terminated in some unexpectd reason that doesn't trigger its
`terminate` function call.
