### PR TITLE
Terminate

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -101,7 +101,6 @@ defmodule Gyro.Arena do
     {:noreply, state}
   end
 
-
   @doc """
   Handle the spinning which is where we update the state of the Arena at an
   interval.

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -39,6 +39,7 @@ defmodule Gyro.Spinner do
       introspect!(spinner_pid)
     catch
       :exit, {:noproc, _} -> nil
+      :exit, _ -> nil
     end
   end
 

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -61,7 +61,6 @@ defmodule Gyro.Spinner do
   Stop the spinner GenServer with a given reason
   """
   def delist(spinner_pid, reason \\ :normal) do
-    Arena.delist(spinner_pid)
     GenServer.stop(spinner_pid, reason)
   end
 

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -120,10 +120,8 @@ defmodule Gyro.Squad do
   listing map by key right now.
   """
   def handle_call({:delist, quitter_pid}, _from, state = %{members: members}) do
-    if Map.has_key?(members, quitter_pid) do
-      members = Map.delete(members, quitter_pid)
-      state = Map.put(state, :members, members)
-    end
+    members = Map.delete(members, quitter_pid)
+    state = Map.put(state, :members, members)
 
     {:reply, state, state}
   end

--- a/web/channels/squad_channel.ex
+++ b/web/channels/squad_channel.ex
@@ -26,8 +26,8 @@ defmodule Gyro.SquadChannel do
   we want to remove the user from the squad they belong to as stored in the
   socket's `assigns` key.
   """
-  def terminate(_, %Socket{assigns: %{squad_pid: squad_pid, spinner_pid: spinner_pid}}) do
-    Squad.delist(squad_pid, spinner_pid)
+  def terminate(_, %Socket{assigns: %{squad_pid: _, spinner_pid: _}}) do
+    #
   end
 
   def handle_info(:init, socket) do


### PR DESCRIPTION
Better handling of when a spinner leave the system.
1. Since we're already doing process monitoring, there's no more need for the spinners to explicitly call to delist itself from arena and or squad. The `:DOWN` message will handle this.
2. We need to also catch a more generic `:exit` message when introspecting spinners as well as there maybe other reason for error than not `:noproc`. Not sure what that is since I haven't looked deeper into it yet but we were getting error during stress testing. So far, this has solve the issue with parent pids (squad/arena) getting killed when making call to spinners.
