### PR TITLE
Call to cast

### DIFF
--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -55,7 +55,7 @@ defmodule Gyro.Spinner do
   Update spinner data.
   """
   def update(spinner_pid, key, value) do
-    GenServer.call(spinner_pid, {:update, key, value})
+    GenServer.cast(spinner_pid, {:update, key, value})
   end
 
   @doc """
@@ -93,9 +93,9 @@ defmodule Gyro.Spinner do
   @doc """
   Handle updating a key in the current state.
   """
-  def handle_call({:update, key, value}, _from, state) do
+  def handle_cast({:update, key, value}, state) do
     state = Map.put(state, key, value)
-    {:reply, state, state}
+    {:noreply, state}
   end
 
   @doc """

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -40,6 +40,13 @@ defmodule Gyro.Squad do
   end
 
   @doc """
+  Stop the given squad GenServer.
+  """
+  def disband(squad_pid, reason \\ :normal) do
+    GenServer.stop(squad_pid, reason)
+  end
+
+  @doc """
   Add the given spinner to a squad of a given name. If the squad doesn't
   already exist, also start it.
   """
@@ -75,13 +82,6 @@ defmodule Gyro.Squad do
   end
 
   @doc """
-  Stop the given squad GenServer.
-  """
-  def disband(squad_pid, reason \\ :normal) do
-    GenServer.stop(squad_pid, reason)
-  end
-
-  @doc """
   Start a new GenServer process for a squad.
   The GenServer will be registered in the global registry with the name. This
   means the squad name is unique and can be referenced by name from anywhere
@@ -111,9 +111,9 @@ defmodule Gyro.Squad do
   @doc """
   Handle updating a key in the current state.
   """
-  def handle_call({:update, key, value}, _, state) do
+  def handle_cast({:update, key, value}, state) do
     state = Map.put(state, key, value)
-    {:reply, state, state}
+    {:noreply, state}
   end
 
   @doc """

--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -15,7 +15,9 @@ defmodule Gyro.ArenaTest do
 
   test "adding a new spinner" do
     {:ok, spinner_pid} = Spinner.start_link()
-    %{spinner_roster: spinner_roster} = Arena.enlist(spinner_pid)
+
+    Arena.enlist(spinner_pid)
+    %{spinner_roster: spinner_roster} = Arena.introspect()
     listed_pid = Agent.get(spinner_roster, fn(state) ->
       state
       |> Map.get(spinner_pid)
@@ -25,7 +27,8 @@ defmodule Gyro.ArenaTest do
   end
 
   test "removing a spinner", %{spinner_pid: spinner_pid} do
-    %{spinner_roster: spinner_roster} = Arena.delist(spinner_pid)
+    Arena.delist(spinner_pid)
+    %{spinner_roster: spinner_roster} = Arena.introspect()
     listed_pid = Agent.get(spinner_roster, fn(state) ->
       state
       |> Map.get(spinner_pid)

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -27,16 +27,18 @@ defmodule Gyro.SquadTest do
   end
 
   test "enlist a spinner to a squad", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
-    %{members: members} = GenServer.call(squad_pid, {:enlist, spinner_pid})
+    GenServer.cast(squad_pid, {:enlist, spinner_pid})
+    %{members: members} = GenServer.call(squad_pid, :introspect)
 
     assert Map.has_key?(members, spinner_pid)
     assert is_member?(spinner_pid, squad_pid)
   end
 
   test "delist a spinner from a squad", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
-    GenServer.call(squad_pid, {:enlist, spinner_pid})
+    GenServer.cast(squad_pid, {:enlist, spinner_pid})
+    GenServer.cast(squad_pid, {:delist, spinner_pid})
 
-    %{members: members} = GenServer.call(squad_pid, {:delist, spinner_pid})
+    %{members: members} = GenServer.call(squad_pid, :introspect)
     assert %{} == members
     refute is_member?(spinner_pid, squad_pid)
   end

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -21,9 +21,10 @@ defmodule Gyro.SquadTest do
   end
 
   test "update state of a squad", %{squad_pid: squad_pid} do
-    state = GenServer.call(squad_pid, {:update, :score, 100})
+    GenServer.cast(squad_pid, {:update, :score, 100})
+    %{score: score} = GenServer.call(squad_pid, :introspect)
 
-    assert %Squad{@squad | score: 100} == state
+    assert 100 == score
   end
 
   test "enlist a spinner to a squad", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do

--- a/web/channels/arena_channel.ex
+++ b/web/channels/arena_channel.ex
@@ -70,13 +70,12 @@ defmodule Gyro.ArenaChannel do
 
   @doc """
   Event handler for spinners to change their name. Currently we're just
-  responding with the name that the spinner gave as confirmation but we
-  should broadcast the message to the chatroom that a spinner has changed
-  their name.
+  responding with the name that the spinner gave as confirmation.
+  TODO: We should broadcast the message to the chatroom that a spinner has
+  changed their name.
   """
   def handle_in("intro", %{ "name" => name } = payload, socket = %Socket{assigns: %{spinner_pid: spinner_pid}}) do
-    spinner = Spinner.update(spinner_pid, :name, name)
-    assign(socket, :spinner, spinner)
+    Spinner.update(spinner_pid, :name, name)
 
     {:reply, {:ok, payload}, socket}
   end


### PR DESCRIPTION
Make all calls to Spinner, Squad, Arena that write to the state a `cast` calls. By making it asynchronous, I don't have to worry about timing out issue, especially when enlisting/delisting spinners in high-volume scenario.
