### PR TITLE
Switch Squad and Arena away from `send_interval`

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -56,7 +56,7 @@ defmodule Gyro.Arena do
   For now, we just need to tell it to start spinning.
   """
   def init(state) do
-    :timer.send_interval(@timer, self, :spin)
+    send(self, :spin)
     {:ok, state}
   end
 
@@ -109,6 +109,7 @@ defmodule Gyro.Arena do
     state = state
     |> update_spinners
 
+    Process.send_after(self, :spin, @timer)
     {:noreply, state}
   end
 

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -97,7 +97,7 @@ defmodule Gyro.Squad do
   For now, we just need to tell it to start spinning.
   """
   def init(state) do
-    :timer.send_interval(@timer, self, :spin)
+    send(self, :spin)
     {:ok, state}
   end
 
@@ -173,6 +173,7 @@ defmodule Gyro.Squad do
     |> update_score(spinners)
     |> update_latest(spinners)
 
+    Process.send_after(self, :spin, @timer)
     {:noreply, state}
   end
 

--- a/web/channels/arena_channel.ex
+++ b/web/channels/arena_channel.ex
@@ -33,7 +33,6 @@ defmodule Gyro.ArenaChannel do
   """
   def handle_info(:init, socket) do
     send(self, :spin)
-    :timer.send_interval(@timer, :spin)
     {:noreply, socket}
   end
 
@@ -51,6 +50,7 @@ defmodule Gyro.ArenaChannel do
     |> Map.delete(:squad_roster)
 
     push socket, "introspect", %{arena: arena, spinner: spinner}
+    Process.send_after(self, :spin, @timer)
     {:noreply, socket}
   end
 

--- a/web/channels/squad_channel.ex
+++ b/web/channels/squad_channel.ex
@@ -23,7 +23,6 @@ defmodule Gyro.SquadChannel do
 
   def handle_info(:init, socket) do
     send(self, :spin)
-    :timer.send_interval(@timer, :spin)
     {:noreply, socket}
   end
 
@@ -39,6 +38,7 @@ defmodule Gyro.SquadChannel do
     socket = assign(socket, :squad, squad)
 
     push socket, "introspect", squad
+    Process.send_after(self, :spin, @timer)
     {:noreply, socket}
   end
 


### PR DESCRIPTION
Since it's not super critical that we have to perform the update at the
interval, it would reduce the workload if we just send the message to do
it again after a period instead. This means we won't have to worry about
the time it takes to complete a spin is longer than the interval calling
spin function.
