### PR TITLE
Squad members

### DIFF
--- a/lib/gyro/scoreboard.ex
+++ b/lib/gyro/scoreboard.ex
@@ -55,6 +55,7 @@ defmodule Gyro.Scoreboard do
     |> Enum.map(fn(item) ->
       item
       |> Map.delete(:created_at)
+      |> Map.delete(:squad_pid)
     end)
   end
 

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -5,7 +5,7 @@ defmodule Gyro.Spinner do
   alias Gyro.Spinner
 
   defstruct name: nil, spm: 1, score: 0,
-    created_at: :calendar.universal_time()
+    squad_pid: nil, created_at: :calendar.universal_time()
 
   @timer 1000
 

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -53,6 +53,7 @@ defmodule Gyro.Squad do
   already exist, also start it.
   """
   def enlist(name, spinner_pid) do
+    delist(spinner_pid)
     case form(name) do
       {:ok, squad_pid} ->
         squad_pid |> GenServer.cast({:enlist, spinner_pid})
@@ -68,6 +69,17 @@ defmodule Gyro.Squad do
   def exists?(name) when is_bitstring(name), do: exists?({:global, name})
   def exists?(name) do
     nil != GenServer.whereis(name)
+  end
+
+  @doc """
+  Remove the given spinner from the squad stored in its state.
+  """
+  def delist(spinner_pid) do
+    %{squad_pid: squad_pid} = Spinner.introspect(spinner_pid)
+    case is_pid(squad_pid) do
+      true -> delist(squad_pid, spinner_pid)
+      _ -> true
+    end
   end
 
   @doc """

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -55,7 +55,8 @@ defmodule Gyro.Squad do
   def enlist(name, spinner_pid) do
     case form(name) do
       {:ok, squad_pid} ->
-        GenServer.cast(squad_pid, {:enlist, spinner_pid})
+        squad_pid |> GenServer.cast({:enlist, spinner_pid})
+        spinner_pid |> Spinner.update(:squad_pid, squad_pid)
         {:ok, squad_pid}
       error -> error
     end
@@ -74,6 +75,7 @@ defmodule Gyro.Squad do
   """
   def delist(squad_pid, spinner_pid) do
     GenServer.cast(squad_pid, {:delist, spinner_pid})
+    spinner_pid |> Spinner.update(:squad_pid, nil)
   end
 
   @doc """

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -60,6 +60,9 @@ defmodule Gyro.SquadTest do
   test "enlist a member", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
     Squad.enlist(@squad.name, spinner_pid)
     assert is_member?(spinner_pid, squad_pid)
+
+    %{squad_pid: result} = Spinner.introspect(spinner_pid)
+    assert @pid == result
   end
 
   test "delist a member", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
@@ -67,6 +70,9 @@ defmodule Gyro.SquadTest do
     Squad.delist(squad_pid, spinner_pid)
 
     refute is_member?(spinner_pid, squad_pid)
+
+    %{squad_pid: result} = Spinner.introspect(spinner_pid)
+    assert nil == result
   end
 
   @tag :skip

--- a/test/gyro/squad_test.exs
+++ b/test/gyro/squad_test.exs
@@ -65,6 +65,13 @@ defmodule Gyro.SquadTest do
     assert @pid == result
   end
 
+  test "delist a spinner from squad stored in its state", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
+    Squad.enlist(squad_pid, spinner_pid)
+    Squad.delist(spinner_pid)
+
+    refute is_member?(spinner_pid, squad_pid)
+  end
+
   test "delist a member", %{squad_pid: squad_pid, spinner_pid: spinner_pid} do
     Squad.enlist(@squad.name, spinner_pid)
     Squad.delist(squad_pid, spinner_pid)

--- a/web/channels/arena_channel.ex
+++ b/web/channels/arena_channel.ex
@@ -42,15 +42,17 @@ defmodule Gyro.ArenaChannel do
   """
   def handle_info(:spin, socket = %Socket{assigns: %{spinner_pid: spinner_pid}}) do
     spinner = Spinner.introspect(spinner_pid)
-    |> Map.delete(:created_at)
-
     socket = assign(socket, :spinner, spinner)
 
     arena = Arena.introspect()
     |> Map.delete(:spinner_roster)
     |> Map.delete(:squad_roster)
 
-    push socket, "introspect", %{"arena" => arena, "spinner" => spinner}
+    spinner_state = spinner
+    |> Map.delete(:squad_pid)
+    |> Map.delete(:created_at)
+
+    push socket, "introspect", %{"arena" => arena, "spinner" => spinner_state}
     Process.send_after(self, :spin, @timer)
     {:noreply, socket}
   end


### PR DESCRIPTION
First step to #26.

The code base will now remove spinner from an existing squad stored in its state before enlisting it to another squad.
