### PR TITLE
Create a supervisor for Squads.

### DIFF
--- a/lib/gyro.ex
+++ b/lib/gyro.ex
@@ -14,6 +14,7 @@ defmodule Gyro do
       # Here you could define other workers and supervisors as children
       # worker(Gyro.Worker, [arg1, arg2, arg3]),
       worker(Gyro.Arena, []),
+      supervisor(Gyro.Squad.Supervisor, []),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -25,10 +25,7 @@ defmodule Gyro.Squad do
       true ->
         {:ok, {:global, name}}
       false ->
-        import Supervisor.Spec
-
-        child = worker(Squad, [%Squad{name: name}, {:global, name}], [name: {:global, name}])
-        case Supervisor.start_child(Gyro.Supervisor, child) do
+        case Gyro.Squad.Supervisor.start_child(name) do
           {:ok, squad_pid} ->
             {:ok, squad_pid}
           {:error, {:already_started, squad_pid}} ->

--- a/lib/gyro/squad/supervisor.ex
+++ b/lib/gyro/squad/supervisor.ex
@@ -1,0 +1,37 @@
+defmodule Gyro.Squad.Supervisor do
+  use Supervisor
+
+  alias Gyro.Squad
+
+  @pid {:global, __MODULE__}
+
+  @doc """
+  The `start_link` is used by `Gyro.Supervisor` to start a supervisor itself.
+  We are passing an atom :ok and an initial state to it as a place holder and
+  give a global name scope so it can be referenced anywhere in the network.
+  """
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok, [name: @pid])
+  end
+
+  @doc """
+  This is a function we call to form a new Squad under this supervisor. We're
+  only accepting just the name of the squad for now with the supervisor
+  deciding on the initial state. For now, the client API won't have access to
+  set the initial state of the Squad.
+  """
+  def start_child(name) do
+    Supervisor.start_child(@pid, [%Squad{name: name}, {:global, name}])
+  end
+
+  @doc """
+  The init function is required by the Supervisor interface thought it's not
+  actually doing anything but start a dummy job with no restart plan. It's
+  only use for declaring the `:simple_one_for_one` strategy for the
+  Supervisor.
+  """
+  def init(:ok) do
+    children = [worker(Gyro.Squad, [], restart: :temporary)]
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end


### PR DESCRIPTION
Fixes #36.

We now have a proper Supervisor implementation for Squads, using a
proper strategy, ie. `:simple_one_for_one`. This will allow us to
dynamically add workers to it with correct pid access to the workers.
