### PR TITLE
Switch Arena to use module name as registered name

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -9,8 +9,7 @@ defmodule Gyro.Arena do
   defstruct spinner_roster: nil, squad_roster: nil,
     heroic_spinners: [], latest_spinners: []
 
-  @name :arena
-  @pid {:global, @name}
+  @pid {:global, __MODULE__}
   @timer 1000
 
   @doc """
@@ -46,7 +45,7 @@ defmodule Gyro.Arena do
     {:ok, squad_roster} <- Agent.start_link((fn() -> %{} end))
     do
       state = %{state | spinner_roster: spinner_roster, squad_roster: squad_roster}
-      GenServer.start_link(__MODULE__, state, name: {:global, @name})
+      GenServer.start_link(__MODULE__, state, name: @pid)
     end
   end
 

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -100,7 +100,6 @@ defmodule Gyro.Squad do
   means the squad name is unique and can be referenced by name from anywhere
   in the system without the process id.
   """
-  def start_link(_, :arena), do: {:error, %{reason: "Reserved name"}}
   def start_link(state, name) do
     GenServer.start_link(__MODULE__, state, name: name)
   end


### PR DESCRIPTION
Fixes #39 

We're now using `__MODULE__` variable as part of the global name tuple
to registered the Arena process. This should help ease the issue of
maintain custom atom and possible name conflict with other process in
the system semantically.
