### PR TITLE
Async

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -5,8 +5,8 @@ defmodule Gyro.Arena do
   alias Gyro.Spinner
   alias Gyro.Scoreboard
 
-  @derive {Poison.Encoder, except: [:spinner_roster, :squad_roster]}
-  defstruct spinner_roster: nil, squad_roster: nil,
+  @derive {Poison.Encoder, except: [:members]}
+  defstruct members: %{},
     score: 0, spm: 0, scoreboard: %Scoreboard{}
 
   @pid {:global, __MODULE__}
@@ -41,12 +41,7 @@ defmodule Gyro.Arena do
   Agent and not starts the arena GenServer.
   """
   def start_link(state \\ %Arena{}) do
-    with {:ok, spinner_roster} <- Agent.start_link((fn() -> %{} end)),
-    {:ok, squad_roster} <- Agent.start_link((fn() -> %{} end))
-    do
-      state = %{state | spinner_roster: spinner_roster, squad_roster: squad_roster}
-      GenServer.start_link(__MODULE__, state, name: @pid)
-    end
+    GenServer.start_link(__MODULE__, state, name: @pid)
   end
 
   @doc """
@@ -66,27 +61,19 @@ defmodule Gyro.Arena do
   end
 
   @doc """
-  Add the given spinner id to the spinner roster Agent.
+  Add the given spinner id to member list in the state
   """
-  def handle_cast({:enlist, spinner_pid}, state = %{spinner_roster: spinner_roster}) do
+  def handle_cast({:enlist, spinner_pid}, state = %{members: members}) do
     Process.monitor(spinner_pid)
-    spinner_roster
-    |> Agent.update(fn(spinners) ->
-      Map.put(spinners, spinner_pid, spinner_pid)
-    end)
-
+    state = %{state | members: Map.put(members, spinner_pid, spinner_pid)}
     {:noreply, state}
   end
 
   @doc """
-  Remove the given spinner id from the spinner roster Agent.
+  Remove the given spinner id from the member list in the state
   """
-  def handle_cast({:delist, spinner_pid}, state = %{spinner_roster: spinner_roster}) do
-    spinner_roster
-    |> Agent.update(fn(spinners) ->
-      Map.delete(spinners, spinner_pid)
-    end)
-
+  def handle_cast({:delist, spinner_pid}, state = %{members: members}) do
+    state = %{state | members: Map.delete(members, spinner_pid)}
     {:noreply, state}
   end
 
@@ -115,9 +102,8 @@ defmodule Gyro.Arena do
   # To update spinner state,  new process is spun up for each member to
   # introspect the state asynchronously. Once we have all members data, we can
   # continue on with the calculations.
-  defp update_spinners(state = %{spinner_roster: spinner_roster, scoreboard: scoreboard}) do
-    spinners = spinner_roster
-    |> Agent.get(&(&1))
+  defp update_spinners(state = %{members: members, scoreboard: scoreboard}) do
+    spinners = members
     |> Stream.map(fn({_, pid}) ->
       Task.async(fn -> Spinner.introspect(pid) end)
     end)

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -7,7 +7,7 @@ defmodule Gyro.Arena do
 
   @derive {Poison.Encoder, except: [:spinner_roster, :squad_roster]}
   defstruct spinner_roster: nil, squad_roster: nil,
-    scoreboard: %Scoreboard{}
+    score: 0, spm: 0, scoreboard: %Scoreboard{}
 
   @pid {:global, __MODULE__}
   @timer 1000

--- a/lib/gyro/scoreboard.ex
+++ b/lib/gyro/scoreboard.ex
@@ -6,9 +6,10 @@ defmodule Gyro.Scoreboard do
     legendaries: [], heroics: [], latest: []
 
   def build(board \\ %Scoreboard{}, list) do
-    board
-    |> build_latest(list)
-    |> build_heroics(list)
+    latest = latest(list)
+    heroics = heroics(list)
+
+    %Scoreboard{board | latest: latest, heroics: heroics}
     |> build_legendaries
   end
 
@@ -23,27 +24,27 @@ defmodule Gyro.Scoreboard do
     end)
   end
 
-  # Private method for finding the newest spinners in the squad.
-  # This is done by iterating through members, sort them by their connected
-  # time, and take only the first 10 from the list.
-  def build_latest(board, list) do
-    latest = list
+  @doc """
+  A method for finding the newest spinners in the squad.
+  This is done by iterating through members, sort them by their connected
+  time, and take only the first 10 from the list.
+  """
+  def latest(list) do
+    list
     |> Enum.sort(&(&1.created_at > &2.created_at))
     |> Enum.take(10)
-
-    %Scoreboard{board | latest: latest}
   end
 
-  # This method is used for updating the heroic_spinners during the spin. It
-  # collects the spinner data by iterating through the spinner roster and ask
-  # for the current spinner state, then sort them by score before taking the
-  # top 10 players.
-  def build_heroics(board, list) do
-    heroics = list
+  @doc """
+  This method is used for updating the heroic_spinners during the spin. It
+  collects the spinner data by iterating through the spinner roster and ask
+  for the current spinner state, then sort them by score before taking the
+  top 10 players.
+  """
+  def heroics(list) do
+    list
     |> Enum.sort(&(&1.score >= &2.score))
     |> Enum.take(10)
-
-    %Scoreboard{board | heroics: heroics}
   end
 
   # This method updates the legendary spinner list based on the new heroic

--- a/lib/gyro/scoreboard.ex
+++ b/lib/gyro/scoreboard.ex
@@ -12,6 +12,17 @@ defmodule Gyro.Scoreboard do
     |> build_legendaries
   end
 
+  @doc """
+  A method for iterating through a given list and return the sum of score and
+  spm.
+  """
+  def total(list) do
+    list
+    |> Enum.reduce({0, 0}, fn(%{score: score, spm: spm}, {acc_score, acc_spm}) ->
+      {acc_score + score, acc_spm + spm}
+    end)
+  end
+
   # Private method for finding the newest spinners in the squad.
   # This is done by iterating through members, sort them by their connected
   # time, and take only the first 10 from the list.

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -180,22 +180,13 @@ defmodule Gyro.Squad do
     |> Enum.filter(&(!is_nil(&1)))
 
     scoreboard_task = Task.async(fn -> Scoreboard.build(spinners) end)
-    score_task = Task.async(fn -> update_score(spinners) end)
+    score_task = Task.async(fn -> Scoreboard.total(spinners) end)
 
     {score, spm} = Task.await(score_task)
     scoreboard  = Task.await(scoreboard_task)
 
     Process.send_after(self, :spin, @timer)
     {:noreply, %{state | score: score, spm: spm, scoreboard: scoreboard}}
-  end
-
-  # Private method for iterating through all members and summing up their
-  # score.
-  defp update_score(spinners) do
-    spinners
-    |> Enum.reduce({0, 0}, fn(%{score: score, spm: spm}, {acc_score, acc_spm}) ->
-      {acc_score + score, acc_spm + spm}
-    end)
   end
 
 end

--- a/lib/gyro/squad/supervisor.ex
+++ b/lib/gyro/squad/supervisor.ex
@@ -31,7 +31,7 @@ defmodule Gyro.Squad.Supervisor do
   Supervisor.
   """
   def init(:ok) do
-    children = [worker(Gyro.Squad, [], restart: :temporary)]
+    children = [worker(Squad, [], restart: :temporary)]
     supervise(children, strategy: :simple_one_for_one)
   end
 end

--- a/test/gyro/arena_test.exs
+++ b/test/gyro/arena_test.exs
@@ -17,22 +17,16 @@ defmodule Gyro.ArenaTest do
     {:ok, spinner_pid} = Spinner.start_link()
 
     Arena.enlist(spinner_pid)
-    %{spinner_roster: spinner_roster} = Arena.introspect()
-    listed_pid = Agent.get(spinner_roster, fn(state) ->
-      state
-      |> Map.get(spinner_pid)
-    end)
+    %{members: members} = Arena.introspect()
+    listed_pid = Map.get(members, spinner_pid)
 
     assert spinner_pid == listed_pid
   end
 
   test "removing a spinner", %{spinner_pid: spinner_pid} do
     Arena.delist(spinner_pid)
-    %{spinner_roster: spinner_roster} = Arena.introspect()
-    listed_pid = Agent.get(spinner_roster, fn(state) ->
-      state
-      |> Map.get(spinner_pid)
-    end)
+    %{members: members} = Arena.introspect()
+    listed_pid = Map.get(members, spinner_pid)
 
     assert listed_pid == nil
   end
@@ -40,18 +34,7 @@ defmodule Gyro.ArenaTest do
   test "inspecting the arena" do
     state = Arena.introspect()
 
-    assert is_pid(state.spinner_roster)
-    assert is_pid(state.squad_roster)
-  end
-
-  @tag :skip
-  test "arena update spinners" do
-    {:ok, spinner_pid} = Spinner.start_link()
-    Arena.enlist(spinner_pid)
-    %{legendary_spinners: legends, heroic_spinners: heroes} = Arena.introspect()
-
-    assert Enum.count(legends) == 2
-    assert Enum.count(heroes) == 2
+    assert Map.has_key?(state, :members)
   end
 
 end

--- a/test/gyro/scoreboard_test.exs
+++ b/test/gyro/scoreboard_test.exs
@@ -20,7 +20,13 @@ defmodule Gyro.ScoreboardTest do
     {:ok, spinner: spinner, another: another, spinners: spinners}
   end
 
-  @tag :skip
+  test "calculate total", %{spinner: spinner, another: another} do
+    {score, spm} = Scoreboard.total([spinner, another])
+
+    assert spinner.score + another.score == score
+    assert spinner.spm + another.spm == spm
+  end
+
   test "building a list of latest", %{spinner: spinner, another: another} do
     %{latest: latest} = Scoreboard.build_latest(%Scoreboard{}, [another, spinner])
     order = Enum.map(latest, &(&1.created_at))
@@ -35,7 +41,6 @@ defmodule Gyro.ScoreboardTest do
     assert order == [spinner.score, another.score]
   end
 
-  @tag :skip
   test "building a list of legendaries", %{spinner: spinner, another: another} do
     board = %Scoreboard{legendaries: [spinner]}
     %{legendaries: legendaries} = Scoreboard.build_legendaries(board, [another, spinner])

--- a/test/gyro/scoreboard_test.exs
+++ b/test/gyro/scoreboard_test.exs
@@ -28,14 +28,14 @@ defmodule Gyro.ScoreboardTest do
   end
 
   test "building a list of latest", %{spinner: spinner, another: another} do
-    %{latest: latest} = Scoreboard.build_latest(%Scoreboard{}, [another, spinner])
+    latest = Scoreboard.latest([another, spinner])
     order = Enum.map(latest, &(&1.created_at))
 
     assert order == [spinner.created_at, another.created_at]
   end
 
   test "building a list of heroics", %{spinner: spinner, another: another} do
-    %{heroics: heroics} = Scoreboard.build_heroics(%Scoreboard{}, [another, spinner])
+    heroics = Scoreboard.heroics([another, spinner])
     order = Enum.map(heroics, &(&1.score))
 
     assert order == [spinner.score, another.score]

--- a/test/gyro/spinner_test.exs
+++ b/test/gyro/spinner_test.exs
@@ -20,10 +20,8 @@ defmodule Gyro.SpinnerTest do
 
   test "enlist a spinner add them to arena" do
     {:ok, spinner_pid} = Spinner.enlist()
-    %{spinner_roster: spinner_roster} = Arena.introspect()
-    found_pid = Agent.get(spinner_roster, fn(state) ->
-      Map.get(state, spinner_pid)
-    end)
+    %{members: members} = Arena.introspect()
+    found_pid = Map.get(members, spinner_pid)
 
     assert spinner_pid == found_pid
   end


### PR DESCRIPTION
Making Squad's scoreboard calculation async. This should make the spinner process more efficient by taking advantage of concurrency. Also lots of clean up and refactoring, including simplifying `Arena` for future extension to allow for both spinners and squads.
