### PR TITLE
GenServer API

### DIFF
--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -1,8 +1,8 @@
 defmodule Gyro.Arena do
   use GenServer
 
-  alias Gyro.Arena
-  alias Gyro.Spinner
+  alias __MODULE__
+  alias Gyro.Arena.Spinnable
   alias Gyro.Scoreboard
 
   @derive {Poison.Encoder, except: [:members]}
@@ -105,7 +105,7 @@ defmodule Gyro.Arena do
   defp inspect_members(members) do
     members
     |> Stream.map(fn({_, pid}) ->
-      Task.async(fn -> Spinner.introspect(pid) end)
+      Task.async(fn -> Spinnable.introspect(pid) end)
     end)
     |> Stream.map(&(Task.await(&1)))
     |> Enum.filter(&(!is_nil(&1)))

--- a/lib/gyro/arena.ex
+++ b/lib/gyro/arena.ex
@@ -103,7 +103,7 @@ defmodule Gyro.Arena do
   # A private method for getting the latest state of processes in a given
   # list.
   defp inspect_members(members) do
-    spinners = members
+    members
     |> Stream.map(fn({_, pid}) ->
       Task.async(fn -> Spinner.introspect(pid) end)
     end)

--- a/lib/gyro/arena/spinnable.ex
+++ b/lib/gyro/arena/spinnable.ex
@@ -1,0 +1,59 @@
+defmodule Gyro.Arena.Spinnable do
+
+  alias __MODULE__
+
+  defmacro __using__(_) do
+    quote do
+      use GenServer
+
+      def introspect(pid), do: Spinnable.introspect(pid)
+      def exists?(pid), do: Spinnable.exists?(pid)
+    end
+  end
+
+  @doc """
+  Check if spinner pid is still alive.
+  """
+  def exists?(nil), do: false
+  def exists?(name) when is_bitstring(name), do: exists?({:global, name})
+  def exists?(pid) when is_pid(pid) do
+    nil != Process.alive?(pid)
+  end
+  def exists?(name), do: GenServer.whereis(name) |> exists?
+
+  @doc """
+  Inspect a list of pids for its state asynchronously.
+  """
+  def introspect(list) when is_list(list) do
+    list
+    |> Stream.map(fn({_, pid}) ->
+      Task.async(fn -> introspect(pid) end)
+    end)
+    |> Stream.map(&(Task.await(&1)))
+    |> Enum.filter(&(!is_nil(&1)))
+  end
+
+  @doc """
+  Inspect the current state of the specified pid. If the process is not
+  found, the function will catch the error message thrown by GenServer and
+  return `nil` value as a result instead.
+  """
+  def introspect(pid) do
+    try do
+      introspect!(pid)
+    catch
+      :exit, {:noproc, _} -> nil
+      :exit, _ -> nil
+    end
+  end
+
+  @doc """
+  Inspect the current state of the specified pid. If the spinner is not
+  found, GenServer will, by default, throw a message.
+  """
+  def introspect!(pid) do
+    GenServer.call(pid, :introspect)
+  end
+
+
+end

--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -1,8 +1,8 @@
 defmodule Gyro.Spinner do
-  use GenServer
+  use Gyro.Arena.Spinnable
 
+  alias __MODULE__
   alias Gyro.Arena
-  alias Gyro.Spinner
 
   @derive {Poison.Encoder, except: [:id, :squad_pid, :created_at]}
   defstruct id: nil, name: nil, spm: 1, score: 0,
@@ -28,37 +28,6 @@ defmodule Gyro.Spinner do
   """
   def delist(spinner_pid, reason \\ :normal) do
     GenServer.stop(spinner_pid, reason)
-  end
-
-  @doc """
-  Check if spinner pid is still alive.
-  """
-  def exists?(nil), do: false
-  def exists?(pid) when is_pid(pid) do
-    nil != Process.alive?(pid)
-  end
-  def exists?(name), do: GenServer.whereis(name) |> exists?
-
-  @doc """
-  Inspect the current state of the specified spinner. If the spinner is not
-  found, the function will catch the error message thrown by GenServer and
-  return `nil` value as a result instead.
-  """
-  def introspect(spinner_pid) do
-    try do
-      introspect!(spinner_pid)
-    catch
-      :exit, {:noproc, _} -> nil
-      :exit, _ -> nil
-    end
-  end
-
-  @doc """
-  Inspect the current state of the specified spinner. If the spinner is not
-  found, GenServer will, by default, throw a message.
-  """
-  def introspect!(spinner_pid) do
-    GenServer.call(spinner_pid, :introspect)
   end
 
   @doc """


### PR DESCRIPTION
Refactor Spinner and Squad functionality into a common abstraction so that Arena can work with both of them but be decoupled from them. This will let me create 2 Arena workers, one for spinners, and one for squads, while sharing the exact same code.
