### PR TITLE
Calendar type

### DIFF
--- a/lib/gyro/spinner.ex
+++ b/lib/gyro/spinner.ex
@@ -4,9 +4,9 @@ defmodule Gyro.Spinner do
   alias __MODULE__
   alias Gyro.Arena
 
-  @derive {Poison.Encoder, except: [:id, :squad_pid, :created_at]}
+  @derive {Poison.Encoder, except: [:id, :squad_pid]}
   defstruct id: nil, name: nil, spm: 1, score: 0,
-    squad_pid: nil, created_at: :calendar.universal_time()
+    squad_pid: nil, created_at: DateTime.utc_now()
 
   @timer 1000
 

--- a/lib/gyro/squad.ex
+++ b/lib/gyro/squad.ex
@@ -5,8 +5,8 @@ defmodule Gyro.Squad do
   alias Gyro.Squad
   alias Gyro.Scoreboard
 
-  @derive {Poison.Encoder, except: [:created_at, :members]}
-  defstruct name: nil, created_at: :calendar.universal_time(), members: %{},
+  @derive {Poison.Encoder, except: [:members]}
+  defstruct name: nil, created_at: DateTime.utc_now(), members: %{},
     score: 0, spm: 0, scoreboard: %Scoreboard{}
 
   @timer 5000

--- a/mix.exs
+++ b/mix.exs
@@ -33,8 +33,8 @@ defmodule Gyro.Mixfile do
     [{:phoenix, "~> 1.2.0"},
      {:phoenix_pubsub, "~> 1.0"},
      {:phoenix_ecto, "~> 3.0-rc"},
-     {:postgrex, "~> 0.11.0"},
-     {:phoenix_html, "~> 2.3"},
+     {:postgrex, "~> 0.11.2"},
+     {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
      {:gettext, "~> 0.9"},
      {:cowboy, "~> 1.0"}]

--- a/web/channels/user_socket.ex
+++ b/web/channels/user_socket.ex
@@ -25,7 +25,7 @@ defmodule Gyro.UserSocket do
   # performing token verification on connect.
   def connect(_params, socket) do
     socket = socket
-    |> assign(:created, :calendar.universal_time())
+    |> assign(:connected, DateTime.utc_now())
 
     # For the SquadChannel to work, it needs to know the spinner pid. Since we
     # currently can't share socket data in assigns between channels, I had to


### PR DESCRIPTION
This should addresses #18. We've marked Elixir 1.3 as a minimum requirement, and now I've replaced `:calendar` call with Elixir's own `DateTime` now. We should be good to go on this end.
